### PR TITLE
Add tests + ESPHome version pin (CI workflow pending token scope)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,70 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+# ESPHome release this firmware is pinned to. Keep in step with `min_version`
+# in the YAML and the pin in requirements-dev.txt.
+env:
+  ESPHOME_VERSION: "2026.5.3"
+
+jobs:
+  esphome:
+    name: ESPHome validate + compile
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Cache PlatformIO toolchain
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.platformio
+            ~/.cache/pip
+          key: pio-${{ runner.os }}-esphome-${{ env.ESPHOME_VERSION }}
+
+      - name: Install ESPHome (pinned)
+        run: pip install "esphome==${ESPHOME_VERSION}"
+
+      - name: Provide CI secrets
+        run: |
+          cat > secrets.yaml <<'YAML'
+          wifi_ssid: "ci"
+          wifi_password: "ci-password-placeholder"
+          api_encryption_key: "MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY="
+          ota_password: "ci-ota-placeholder"
+          fallback_ap_password: "ci-fallback-placeholder"
+          YAML
+
+      - name: Validate config (schema lint, version floor)
+        run: |
+          esphome config della-slwf.yaml
+          esphome config della-la.yaml
+
+      - name: Compile firmware (builds the custom C++ component)
+        run: esphome compile della-slwf.yaml
+
+  python:
+    name: Python protocol tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install test deps
+        run: pip install "pytest>=8,<9"
+
+      - name: Byte-compile all scripts
+        run: python -m compileall -q *.py components/della_ac/*.py
+
+      - name: Run tests
+        run: pytest -q

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,5 @@
+import os
+import sys
+
+# Make the repo-root modules (analyze_bursts, pulse2bytes) importable from tests.
+sys.path.insert(0, os.path.dirname(__file__))

--- a/della-la.yaml
+++ b/della-la.yaml
@@ -14,6 +14,7 @@
 esphome:
   name: della-slwf
   friendly_name: Della Mini Split
+  min_version: 2026.5.3
 
 esp8266:
   board: esp12e

--- a/della-slwf.yaml
+++ b/della-slwf.yaml
@@ -26,6 +26,9 @@
 esphome:
   name: della-slwf
   friendly_name: Della Mini Split
+  # Firmware requires features from this ESPHome release or newer; older
+  # versions fail validation. CI pins the exact build (see .github/workflows).
+  min_version: 2026.5.3
 
 esp8266:
   board: esp12e

--- a/della_ctl.py
+++ b/della_ctl.py
@@ -55,5 +55,6 @@ async def main():
         await asyncio.sleep(float(sys.argv[2]))
     await cli.disconnect()
 
-asyncio.run(main())
-# appended: 'service' subcommand handled inline above via execute_service
+
+if __name__ == '__main__':
+    asyncio.run(main())

--- a/pulse2bytes.py
+++ b/pulse2bytes.py
@@ -61,10 +61,15 @@ def show(name, t):
         calc = crc16_rfc1071(body)
         print(f"CRC16 in frame: {crc:04X}  calculated: {calc:04X}  {'VALID' if crc == calc else 'MISMATCH'}")
 
-if len(sys.argv) < 2:
-    sys.exit(__doc__)
-bursts = parse(sys.argv[1])
-hb = next(t for ts, t in bursts if lows_sig(t) == HB and len(t) == 33)
-show("HEARTBEAT", hb)
-for idx, (ts, t) in enumerate([(ts, t) for ts, t in bursts if not (lows_sig(t) == HB and len(t) == 33)]):
-    show(f"STATUS {idx} @ {ts}", t)
+def main(path):
+    bursts = parse(path)
+    hb = next(t for ts, t in bursts if lows_sig(t) == HB and len(t) == 33)
+    show("HEARTBEAT", hb)
+    for idx, (ts, t) in enumerate([(ts, t) for ts, t in bursts if not (lows_sig(t) == HB and len(t) == 33)]):
+        show(f"STATUS {idx} @ {ts}", t)
+
+
+if __name__ == '__main__':
+    if len(sys.argv) < 2:
+        sys.exit(__doc__)
+    main(sys.argv[1])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,5 @@
+[tool.pytest.ini_options]
+# Only the tests/ directory holds unit tests. The repo-root `test_ladder.py`
+# is a device-driving script (matches pytest's test_*.py glob but is not a
+# unit test), so restrict collection here.
+testpaths = ["tests"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,11 @@
+# Pin the ESPHome build this firmware targets. Keep in sync with `min_version`
+# in della-slwf.yaml / della-la.yaml and the CI workflow.
+esphome==2026.5.3
+
+# Test runner for the protocol tools.
+pytest>=8,<9
+
+# Runtime deps for the device-facing helper scripts (della_ctl.py,
+# test_ladder.py, ir_sweep.py). Not needed to run the test suite.
+pyyaml
+aioesphomeapi

--- a/test_ladder.py
+++ b/test_ladder.py
@@ -127,4 +127,6 @@ def report(p, f):
     for n in f:
         print(f"  FAILED: {n}")
 
-asyncio.run(main())
+
+if __name__ == '__main__':
+    asyncio.run(main())

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -1,0 +1,70 @@
+"""Pure-logic tests for the AUX protocol decode tools.
+
+These do not need a device. They exercise:
+  - the CRC16 (RFC1071) implementation,
+  - that the firmware's hard-coded TX frames carry correct CRCs,
+  - the full pulse -> bits -> 8E1 bytes pipeline against a real captured frame.
+"""
+import pytest
+
+from pulse2bytes import to_bits, to_bytes, crc16_rfc1071
+from analyze_bursts import parse, lows_sig, HB
+
+# Real AUX frames (full, including the trailing 2 CRC bytes). The first four are
+# the exact byte strings the firmware transmits, so this also guards them.
+FRAMES = {
+    "ping":          "BB 00 01 00 00 00 00 00 43 FF",
+    "small_request": "BB 00 06 80 00 00 02 00 11 01 2B 7E",
+    "big_request":   "BB 00 06 80 00 00 02 00 21 01 1B 7E",
+    "ping_answer":   "BB 00 01 80 01 00 08 00 1C 27 00 00 00 00 00 00 1E 58",
+    "big_status":    "BB 00 07 00 00 00 18 00 01 20 E4 21 00 02 55 35 2E 2E 2E "
+                     "64 3A 3D 40 39 14 06 A4 2C 08 00 00 03 54 47",
+}
+
+# A real captured heartbeat burst (ESPHome remote.raw timings, microseconds).
+# Decodes to the ping frame above.
+HEARTBEAT_TIMINGS = [
+    -206, 412, -206, 619, -205, 206, -206, 258, -2060, 258, -206, 206, -1442,
+    464, -2060, 258, -2060, 258, -2060, 257, -2061, 412, -2060, 258, -206, 412,
+    -825, 205, -206, 464, -206, 1648, -206,
+]
+
+
+@pytest.mark.parametrize("name,hexstr", FRAMES.items())
+def test_crc_matches_frame(name, hexstr):
+    data = bytes.fromhex(hexstr.replace(" ", ""))
+    body, expected = data[:-2], (data[-2] << 8) | data[-1]
+    assert crc16_rfc1071(body) == expected, f"{name} CRC mismatch"
+
+
+def test_heartbeat_decodes_to_ping():
+    data = bytes(v for v, _ in to_bytes(to_bits(HEARTBEAT_TIMINGS)))
+    assert data == bytes.fromhex(FRAMES["ping"].replace(" ", ""))
+
+
+def test_heartbeat_no_parity_errors():
+    assert all(ok for _, ok in to_bytes(to_bits(HEARTBEAT_TIMINGS)))
+
+
+def test_lows_signature_classifies_heartbeat(tmp_path):
+    log = tmp_path / "hb.log"
+    timings = ", ".join(str(v) for v in HEARTBEAT_TIMINGS)
+    log.write_text(f"[12:30:10.155][I][remote.raw:035]: Received Raw: {timings}\n")
+    bursts = parse(str(log))
+    assert len(bursts) == 1
+    ts, t = bursts[0]
+    assert len(t) == len(HEARTBEAT_TIMINGS)
+    assert lows_sig(t) == HB
+
+
+def test_parse_merges_chunked_burst(tmp_path):
+    # ESPHome splits long bursts across indented continuation lines; parse()
+    # must stitch them back into a single burst.
+    log = tmp_path / "chunked.log"
+    log.write_text(
+        "[01:02:03.400][I][remote.raw:026]: Received Raw: -206, 412, -206, 618\n"
+        "[01:02:03.400][I][remote.raw:026]:   -206, 206, -2060, 258\n"
+    )
+    bursts = parse(str(log))
+    assert len(bursts) == 1
+    assert len(bursts[0][1]) == 8


### PR DESCRIPTION
## What this adds

CI scaffolding plus a small, real test suite. Nothing heavy.

> **One blocker:** the `.github/workflows/ci.yml` file is **not** in this push yet — the
> pushing token lacks GitHub's `workflow` scope, which is required to add workflow files.
> The workflow is written and validated locally; it lands the moment the token gets
> `workflow` scope (or it can be added through the GitHub UI). Everything else is here and
> reviewable.

### Version binding
ESPHome's defined way to pin a build floor is **`min_version:`** in the `esphome:` block.
Both YAMLs now declare `min_version: 2026.5.3`, so validation fails on an older ESPHome.
CI will pin the exact build with `esphome==2026.5.3`; `requirements-dev.txt` records the
same pin for local dev. Bump the two together.

### Tests (`tests/test_protocol.py`) — 9 cases, all green locally
- **CRC16 (RFC1071) known-answers.** The vectors are real frames; four are the exact byte
  strings the firmware transmits (ping answer, small/big status requests), so this doubles
  as a guard that those hard-coded TX frames carry correct CRCs.
- **Full decode pipeline.** `pulse -> bits -> 8E1 bytes` over a real captured heartbeat,
  asserting it yields the ping frame with no parity errors.
- **Parser coverage.** `parse()` / `lows_sig()`, including a chunked multi-line burst.

### The CI workflow (pending the scope, for reference)
`.github/workflows/ci.yml` defines two jobs on push-to-master and PRs:
- **esphome** — pinned `esphome==2026.5.3`; `esphome config` on both YAMLs (schema lint +
  the `min_version` floor check), then `esphome compile della-slwf.yaml`. The compile is
  the load-bearing one: it builds the custom C++ component, so it catches ESPHome C++ API
  drift between releases.
- **python** — byte-compile every script, then `pytest`.

### Housekeeping
- Device-driving scripts (`test_ladder.py`, `della_ctl.py`) guard their entrypoint under
  `__main__`; `pulse2bytes.py` functions are importable; `pyproject.toml` scopes pytest to
  `tests/` so the device scripts aren't collected.

Verified locally: `esphome config` valid on both YAMLs, `esphome compile` succeeds, and
9/9 pytest pass.
