### PR TITLE
Clean default HA logs + runtime Verbose logs toggle

### DIFF
--- a/components/della_ac/della_ac.h
+++ b/components/della_ac/della_ac.h
@@ -84,6 +84,32 @@ class DellaAC : public climate::Climate, public Component, public uart::UARTDevi
 
     bool changed = mode != this->mode || fan != this->fan_mode || swing != this->swing_mode ||
                    preset != this->preset || fabsf(target - this->target_temperature) > 0.05f;
+
+    // Clean, human-readable state logging at INFO: one summary line on first
+    // sync, then only what actually changed. No per-poll spam.
+    if (this->first_publish_) {
+      ESP_LOGI(TAG, "State: %s, target %.1f C, fan %s",
+               LOG_STR_ARG(climate::climate_mode_to_string(mode)), target,
+               LOG_STR_ARG(climate::climate_fan_mode_to_string(fan)));
+    } else {
+      if (mode != this->mode)
+        ESP_LOGI(TAG, "Mode: %s -> %s", LOG_STR_ARG(climate::climate_mode_to_string(this->mode)),
+                 LOG_STR_ARG(climate::climate_mode_to_string(mode)));
+      if (fabsf(target - this->target_temperature) > 0.05f)
+        ESP_LOGI(TAG, "Target: %.1f -> %.1f C", this->target_temperature, target);
+      if (fan != this->fan_mode)
+        ESP_LOGI(TAG, "Fan: %s -> %s",
+                 LOG_STR_ARG(climate::climate_fan_mode_to_string(this->fan_mode.value())),
+                 LOG_STR_ARG(climate::climate_fan_mode_to_string(fan)));
+      if (swing != this->swing_mode)
+        ESP_LOGI(TAG, "Swing: %s -> %s", LOG_STR_ARG(climate::climate_swing_mode_to_string(this->swing_mode)),
+                 LOG_STR_ARG(climate::climate_swing_mode_to_string(swing)));
+      if (preset != this->preset)
+        ESP_LOGI(TAG, "Preset: %s -> %s",
+                 LOG_STR_ARG(climate::climate_preset_to_string(this->preset.value())),
+                 LOG_STR_ARG(climate::climate_preset_to_string(preset)));
+    }
+
     this->mode = mode;
     this->target_temperature = target;
     this->fan_mode = fan;

--- a/della-slwf.yaml
+++ b/della-slwf.yaml
@@ -42,8 +42,9 @@ external_components:
       path: components
 
 logger:
-  baud_rate: 0
-  level: DEBUG
+  baud_rate: 0          # keep the logger off the UART pins
+  level: INFO           # clean by default; the "Verbose logs" switch adds
+                        # per-frame detail at runtime without a reflash
 
 api:
   encryption:
@@ -93,6 +94,9 @@ globals:
   - id: poll_phase            # alternate small/big
     type: bool
     initial_value: 'false'
+  - id: link_up               # last-published link state (for up/down logging)
+    type: bool
+    initial_value: 'false'
 
 climate:
   - platform: della_ac
@@ -118,7 +122,9 @@ script:
 remote_receiver:
   pin:
     number: GPIO14
-  dump: raw
+  # No `dump:` — on_raw still fires, but we skip ESPHome's built-in per-burst
+  # pulse-timing log line (that was the 1 Hz spam). Frame-level detail is
+  # available at runtime via the "Verbose logs" switch instead.
   filter: 20us
   # 8ms: longest legit intra-frame high is ~1.7ms; the unit can emit separate
   # frames as little as ~11ms apart (observed ping 10.9ms after a poll reply
@@ -211,7 +217,7 @@ remote_receiver:
 
           // ---------------- SET ACK (4-byte body echoes our CRC) ----------------
           if (data.size() == 14 && data[2] == 0x07 && data[9] == 0x01) {
-            ESP_LOGI("aux", "SET ACK: %s", hex.c_str());
+            if (id(verbose_logs).state) ESP_LOGI("della.rx", "SET ACK: %s", hex.c_str());
             return;
           }
 
@@ -249,6 +255,8 @@ remote_receiver:
               pos++;
               continue;
             }
+            if (id(verbose_logs).state)
+              ESP_LOGI("della.rx", "RX %s", hex.c_str());
             dispatch(data, hex, now);
             good_frames++;
             pos += flen;
@@ -285,13 +293,25 @@ interval:
           bool alive = (id(ping_count) + id(status_count)) > 0 &&
                        (millis() - id(last_rx_ms)) < 15000;
           id(mcu_link).publish_state(alive);
+          if (alive != id(link_up)) {            // log only the transition
+            id(link_up) = alive;
+            ESP_LOGI("della", "AC link %s", alive ? "up" : "lost");
+          }
 
 switch:
+  - platform: template
+    name: "Verbose logs"
+    id: verbose_logs
+    icon: mdi:text-search
+    entity_category: config
+    optimistic: true
+    restore_mode: RESTORE_DEFAULT_OFF
   - platform: template
     name: "Ping ACK (module presence)"
     id: ping_ack_enable
     icon: mdi:handshake
     entity_category: config
+    disabled_by_default: true   # advanced/diagnostic
     optimistic: true
     restore_mode: RESTORE_DEFAULT_ON
   - platform: template
@@ -330,11 +350,15 @@ number:
     mode: box
 
 button:
+  - platform: restart
+    name: "Restart"
+    entity_category: diagnostic
   - platform: template
     name: "Request status now"
     id: btn_poll_now
     icon: mdi:download
     entity_category: config
+    disabled_by_default: true   # advanced; auto-poll already keeps state fresh
     on_press:
       - script.execute: send_small_request
       - delay: 700ms
@@ -386,13 +410,26 @@ sensor:
     name: "Fan speed code"
     icon: mdi:fan
     accuracy_decimals: 0
+    entity_category: diagnostic   # raw code; the climate fan mode is user-facing
+    disabled_by_default: true
     update_interval: never
+  # Standard device-management niceties users expect on an ESP device.
+  - platform: wifi_signal
+    name: "Wi-Fi signal"
+    entity_category: diagnostic
+    update_interval: 60s
+  - platform: uptime
+    name: "Uptime"
+    entity_category: diagnostic
+    disabled_by_default: true
+    update_interval: 60s
   - platform: template
     id: hb_interval
     name: "MCU ping interval"
     unit_of_measurement: s
     accuracy_decimals: 2
     entity_category: diagnostic
+    disabled_by_default: true
     update_interval: never
     filters:
       - delta: 0.4
@@ -403,6 +440,7 @@ sensor:
     accuracy_decimals: 0
     state_class: total_increasing
     entity_category: diagnostic
+    disabled_by_default: true
     update_interval: never
   - platform: template
     id: status_count_sensor
@@ -411,6 +449,7 @@ sensor:
     accuracy_decimals: 0
     state_class: total_increasing
     entity_category: diagnostic
+    disabled_by_default: true
     update_interval: never
   - platform: template
     id: bad_frame_count_sensor
@@ -419,6 +458,7 @@ sensor:
     accuracy_decimals: 0
     state_class: total_increasing
     entity_category: diagnostic
+    disabled_by_default: true
     update_interval: never
 
 text_sensor:
@@ -427,18 +467,21 @@ text_sensor:
     name: "Last status frame"
     icon: mdi:matrix
     entity_category: diagnostic
+    disabled_by_default: true
     update_interval: never
   - platform: template
     id: last_small_frame
     name: "Last small frame"
     icon: mdi:matrix
     entity_category: diagnostic
+    disabled_by_default: true
     update_interval: never
   - platform: template
     id: unknown_frame
     name: "Last unknown frame"
     icon: mdi:alert-decagram
     entity_category: diagnostic
+    disabled_by_default: true
     update_interval: never
 
 binary_sensor:


### PR DESCRIPTION
## Problem

The firmware ran `logger: level: DEBUG` with `remote_receiver: dump: raw`, so every poll (~1 Hz) dumped a raw pulse-timing line into the HA/ESPHome log. For a normal user that's noise — raw command/poll traffic, not status.

## Default is now quiet and event-driven

- **`logger` level `INFO`** and **`dump: raw` removed.** `on_raw` still fires (decoding is unaffected) — only ESPHome's built-in per-burst log line goes away, which was the spam.
- **Human-readable state logging** in the climate component: one summary line on first sync, then *only what changed* — `Mode: cool -> heat`, `Target: 22.7 -> 23.0 C`, `Fan: auto -> high`, swing, preset. Plus an `AC link up/lost` transition line. Nothing per-poll.
- **New `Verbose logs` switch** (runtime, default **off**): turns per-frame RX hex + SET-ACK logging back on for debugging — no reflash needed.

## Cleaner HA device page

What a mini-split user expects, nothing more.

- **Disabled by default** (still there if you enable them): the three raw-frame text sensors, MCU ping interval, ping/status/bad-frame counters, the raw fan-speed code, and the advanced `Ping ACK` / `Request status now` controls.
- **Kept visible:** the climate entity, indoor / outdoor / coil / compressor temperatures, inverter power, and the MCU-link connectivity sensor.
- **Added** standard device-management entities people expect: **Wi-Fi signal**, **Uptime** (diagnostic), and a **Restart** button.

## Validation

`esphome config` valid and `esphome compile della-slwf.yaml` succeeds. Not flashed to the live unit from here: its API/OTA credentials have rotated since this work began (it appears to have been re-adopted under its own HA/ESPHome management), so on-device validation should happen from that environment.
