### PR TITLE
Add swing modes, feature controls, and status/setpoint/fan-speed sensors

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,15 @@ story and byte-level map are in [`docs/PROTOCOL.md`](docs/PROTOCOL.md).
 ## Features
 
 - **Full climate entity** — off / cool / heat / dry / fan-only / heat_cool, fan
-  auto / low / medium / high / quiet, vertical swing, boost (turbo) and sleep presets,
-  current temperature and HVAC action
-- **Telemetry sensors** — evaporator-coil, compressor and outdoor temperatures, plus
-  inverter power %
+  auto / low / medium / high / quiet, vertical / horizontal / both swing, boost (turbo)
+  and sleep presets, current temperature and HVAC action
+- **Feature controls** — Home Assistant entities for the panel display, health
+  (ionizer), eco, self-clean and the anti-fungus dry cycle, each mapped to the remote's
+  real behaviour — the off-state-only functions (self-clean, anti-fungus) are handled
+  as such instead of no-op toggles
+- **Telemetry & status sensors** — evaporator-coil, compressor and outdoor temperatures,
+  inverter power %, the live blower speed, a typed setpoint sensor, and a one-line
+  human-readable status summary
 - **Robust RX** — receives over a pulse-capture path that is immune to the AC MCU's
   ragged rising edges, then reconstructs and CRC-checks every frame on-device
 - **Safe writes** — each command is built by copying the unit's latest status frame and

--- a/components/della_ac/della_ac.h
+++ b/components/della_ac/della_ac.h
@@ -10,7 +10,8 @@
 // at the 1 s poll cadence it is ~2 s old at most).
 //
 // Protocol facts (full map: docs/PROTOCOL.md):
-//   small body: [2] vlouver(0-2)|setpoint-8<<3   [4] ir-min(0-5)|frac.5(7)
+//   small body: [2] vlouver(0-2: 0=swing)|setpoint-8<<3   [3] hlouver(5-7: 0=swing)
+//               [4] ir-min(0-5)|frac.5(7)
 //               [5] fan(0xE0: 20=HI 40=MED 60=LO A0=AUTO)
 //               [6] turbo(0x40)|mute(0x80)
 //               [7] mode(0xE0: 00=auto 20=cool 40=dry 80=heat C0=fan)
@@ -73,8 +74,11 @@ class DellaAC : public climate::Climate, public Component, public uart::UARTDevi
       }
     }
 
+    bool v_swing = (body[2] & 0x07) == 0x00;   // v_louver 0 = swing, 7 = fixed
+    bool h_swing = (body[3] & 0xE0) == 0x00;   // h_louver 0 = swing, 0x20 = fixed
     climate::ClimateSwingMode swing =
-        ((body[2] & 0x07) == 0x00) ? climate::CLIMATE_SWING_VERTICAL : climate::CLIMATE_SWING_OFF;
+        v_swing ? (h_swing ? climate::CLIMATE_SWING_BOTH : climate::CLIMATE_SWING_VERTICAL)
+                : (h_swing ? climate::CLIMATE_SWING_HORIZONTAL : climate::CLIMATE_SWING_OFF);
 
     climate::ClimatePreset preset = climate::CLIMATE_PRESET_NONE;
     if (body[6] & 0x40)
@@ -122,8 +126,9 @@ class DellaAC : public climate::Climate, public Component, public uart::UARTDevi
     }
   }
 
-  void ingest_big(float indoor, uint8_t inverter_power) {
+  void ingest_big(float indoor, uint8_t inverter_power, uint8_t fan_actual) {
     this->inverter_power_ = inverter_power;
+    this->fan_actual_ = fan_actual;
     bool changed = isnan(this->current_temperature) ||
                    fabsf(indoor - this->current_temperature) > 0.05f;
     this->current_temperature = indoor;
@@ -132,24 +137,149 @@ class DellaAC : public climate::Climate, public Component, public uart::UARTDevi
       this->publish_state();
   }
 
-  // display on/off (small body[12] bit 4) — for a YAML template switch
-  void set_display(bool on) {
-    if (!this->fresh_()) {
-      ESP_LOGW(TAG, "display: no fresh small status, refusing");
-      return;
-    }
+  // Single-bit feature toggles in the small-status body, exposed as YAML
+  // template switches. All route through set_feature_(), which rebuilds the SET
+  // from the latest status WITH setpoint compensation, so toggling a feature
+  // never erodes a fractional setpoint.
+  void set_display(bool on) { this->set_feature_(12, 0x10, on); }     // panel light
+  bool display_state() const { return this->feature_state_(12, 0x10); }
+  void set_health(bool on) { this->set_feature_(10, 0x03, on); }      // ionizer/health (IR-confirmed: bits 0+1)
+  bool health_state() const { return this->feature_state_(10, 0x03); }
+  void set_eco(bool on) { this->set_feature_(10, 0x08, on); }         // energy-save (IR-confirmed [10].3)
+  bool eco_state() const { return this->feature_state_(10, 0x08); }
+
+  // Self-clean and Anti-fungus are OFF-STATE functions (verified live on the
+  // unit): the AC only honors them with the power bit cleared, so they force
+  // power off in the SET rather than being plain set_feature_() toggles.
+  void press_iclean() {                       // start the evaporator self-clean cycle
     uint8_t b[15];
-    memcpy(b, this->small_body_, 15);
-    b[0] = 0x01; b[1] = 0x01;
-    b[4] &= 0x80;
-    if (on) b[12] |= 0x10; else b[12] &= ~0x10;
+    if (!this->prepare_set_(b))
+      return;
+    b[10] = (b[10] & ~0x20) | 0x04;           // power off + iClean active (observed state = 0x04)
     this->send_cmd_(b);
   }
+  // "actively self-cleaning" = clean bit set AND power off (the real cycle
+  // reports power-off + 0x04). A stray 0x04 on a powered unit is not a cycle.
+  bool iclean_state() const { return this->have_small_ && (this->small_body_[10] & 0x24) == 0x04; }
+  void set_antifungus(bool on) {              // arm/disarm the shutdown dry cycle ([12].3)
+    uint8_t b[15];
+    if (!this->prepare_set_(b))
+      return;
+    b[10] &= ~0x20;                           // anti-f is only accepted with the unit off
+    if (on) b[12] |= 0x08; else b[12] &= ~0x08;
+    this->send_cmd_(b);
+  }
+  bool antifungus_state() const { return this->feature_state_(12, 0x08); }
 
-  bool display_state() const { return this->have_small_ && (this->small_body_[12] & 0x10); }
+  // Big-frame [13] = reported live blower speed. Mapped on the unit (2/4/6).
+  const char *fan_actual_str() const {
+    switch (this->fan_actual_) {
+      case 2: return "low";
+      case 4: return "med";
+      case 6: return "high";
+      case 0: return "idle";
+      default: return "?";
+    }
+  }
+
+  // One readable summary for the "Status" text sensor. Folding setpoint, mode,
+  // fan, swing, preset and active features into a single string means a
+  // setpoint change (a climate attribute HA's logbook ignores) — and every
+  // other change — lands as one state change in the HA history/logbook.
+  std::string status_line() {
+    // NOTE: build only from plain string literals. On ESP8266 the climate_*_to_string
+    // helpers return LOG_STR (PROGMEM) pointers; feeding those to std::string does a
+    // byte-wise flash read that faults and crash-loops the device.
+    if (!this->have_small_)
+      return "--";
+    if (this->mode == climate::CLIMATE_MODE_OFF) {
+      std::string s = this->iclean_state() ? "self-clean" : "off";
+      if (this->antifungus_state()) s += " | anti-fungus armed";
+      return s;
+    }
+    const char *mode_s;
+    switch (this->mode) {
+      case climate::CLIMATE_MODE_COOL: mode_s = "cool"; break;
+      case climate::CLIMATE_MODE_HEAT: mode_s = "heat"; break;
+      case climate::CLIMATE_MODE_DRY: mode_s = "dry"; break;
+      case climate::CLIMATE_MODE_FAN_ONLY: mode_s = "fan"; break;
+      default: mode_s = "auto"; break;  // HEAT_COOL
+    }
+    std::string s = mode_s;
+    bool degf = this->small_body_[7] & 0x02;
+    float disp = degf ? this->target_temperature * 9.0f / 5.0f + 32.0f : this->target_temperature;
+    char buf[24];
+    snprintf(buf, sizeof(buf), degf ? " %.0fF" : " %.1fC", disp);
+    s += buf;
+    const char *fan_s;
+    switch (this->fan_mode.value()) {
+      case climate::CLIMATE_FAN_HIGH: fan_s = "high"; break;
+      case climate::CLIMATE_FAN_MEDIUM: fan_s = "med"; break;
+      case climate::CLIMATE_FAN_LOW: fan_s = "low"; break;
+      case climate::CLIMATE_FAN_QUIET: fan_s = "quiet"; break;
+      default: fan_s = "auto"; break;
+    }
+    s += " | fan "; s += fan_s;
+    // In Auto the unit picks a speed — surface what it's actually running.
+    if (this->fan_mode.value() == climate::CLIMATE_FAN_AUTO && this->fan_actual_) {
+      s += " ("; s += this->fan_actual_str(); s += ")";
+    }
+    if (this->swing_mode != climate::CLIMATE_SWING_OFF) {
+      const char *sw;
+      switch (this->swing_mode) {
+        case climate::CLIMATE_SWING_BOTH: sw = "both"; break;
+        case climate::CLIMATE_SWING_VERTICAL: sw = "vert"; break;
+        case climate::CLIMATE_SWING_HORIZONTAL: sw = "horiz"; break;
+        default: sw = "off"; break;
+      }
+      s += " | swing "; s += sw;
+    }
+    if (this->preset.value() == climate::CLIMATE_PRESET_BOOST) s += " | turbo";
+    else if (this->preset.value() == climate::CLIMATE_PRESET_SLEEP) s += " | sleep";
+    if (this->health_state()) s += " | health";
+    if (this->eco_state()) s += " | eco";
+    if (this->antifungus_state()) s += " | anti-fungus";
+    return s;
+  }
 
  protected:
   bool fresh_() { return this->have_small_ && (millis() - this->last_small_ms_) < 15000; }
+
+  // Rebuild a SET body from the latest small status: command bytes set,
+  // IR-minutes cleared, and the *current* setpoint re-encoded with the
+  // tenths+1 compensation (so a feature toggle doesn't erode a fractional
+  // setpoint — see control()). Returns false if there's no fresh status.
+  bool prepare_set_(uint8_t b[15]) {
+    if (!this->fresh_()) {
+      ESP_LOGW(TAG, "set: no fresh small status, refusing");
+      return false;
+    }
+    memcpy(b, this->small_body_, 15);
+    b[0] = 0x01; b[1] = 0x01;
+    b[4] &= 0x80;
+    float t = 8.0f + ((b[2] >> 3) & 0x1F) + b[14] / 10.0f;
+    uint8_t send_int = (uint8_t) t;
+    uint8_t send_tenths = ((uint8_t) lroundf(t * 10.0f)) % 10;
+    if (send_tenths != 0 && send_tenths != 5) {
+      send_tenths += 1;
+      if (send_tenths == 10) { send_tenths = 0; send_int += 1; }
+    }
+    b[2] = (b[2] & 0x07) | (uint8_t)((send_int - 8) << 3);
+    b[14] = send_tenths;
+    b[4] = (b[4] & 0x7F) | (send_tenths == 5 ? 0x80 : 0x00);
+    return true;
+  }
+
+  void set_feature_(uint8_t idx, uint8_t mask, bool on) {
+    uint8_t b[15];
+    if (!this->prepare_set_(b))
+      return;
+    if (on) b[idx] |= mask; else b[idx] &= ~mask;
+    this->send_cmd_(b);
+  }
+  bool feature_state_(uint8_t idx, uint8_t mask) const {
+    return this->have_small_ && (this->small_body_[idx] & mask);
+  }
 
   // returns true if action changed
   bool update_action_() {
@@ -246,8 +376,10 @@ class DellaAC : public climate::Climate, public Component, public uart::UARTDevi
 
     if (call.get_swing_mode().has_value()) {
       auto s = *call.get_swing_mode();
-      // 0 = swing, 7 = stop at current position
-      b[2] = (b[2] & ~0x07) | (s == climate::CLIMATE_SWING_VERTICAL ? 0x00 : 0x07);
+      bool v = s == climate::CLIMATE_SWING_VERTICAL || s == climate::CLIMATE_SWING_BOTH;
+      bool h = s == climate::CLIMATE_SWING_HORIZONTAL || s == climate::CLIMATE_SWING_BOTH;
+      b[2] = (b[2] & ~0x07) | (v ? 0x00 : 0x07);   // v_louver: 0 = swing, 7 = fixed
+      b[3] = (b[3] & ~0xE0) | (h ? 0x00 : 0x20);   // h_louver: 0 = swing, 0x20 = fixed
       this->swing_mode = s;
     }
 
@@ -257,6 +389,12 @@ class DellaAC : public climate::Climate, public Component, public uart::UARTDevi
       b[7] = (b[7] & ~0x04) | (p == climate::CLIMATE_PRESET_SLEEP ? 0x04 : 0x00);
       this->preset = p;
     }
+
+    // Self-clean is mutually exclusive with a running mode: never command (or
+    // leave) the clean bit set while powered on, else the unit gets stuck at
+    // 0x24 (cooling + clean-flag) after a cycle is cancelled with power.
+    if (b[10] & 0x20)
+      b[10] &= ~0x04;
 
     this->send_cmd_(b);
     this->update_action_();
@@ -297,7 +435,8 @@ class DellaAC : public climate::Climate, public Component, public uart::UARTDevi
     t.set_supported_fan_modes({climate::CLIMATE_FAN_AUTO, climate::CLIMATE_FAN_LOW,
                                climate::CLIMATE_FAN_MEDIUM, climate::CLIMATE_FAN_HIGH,
                                climate::CLIMATE_FAN_QUIET});
-    t.set_supported_swing_modes({climate::CLIMATE_SWING_OFF, climate::CLIMATE_SWING_VERTICAL});
+    t.set_supported_swing_modes({climate::CLIMATE_SWING_OFF, climate::CLIMATE_SWING_VERTICAL,
+                                 climate::CLIMATE_SWING_HORIZONTAL, climate::CLIMATE_SWING_BOTH});
     t.set_supported_presets({climate::CLIMATE_PRESET_NONE, climate::CLIMATE_PRESET_BOOST,
                              climate::CLIMATE_PRESET_SLEEP});
     t.set_visual_min_temperature(16);
@@ -312,6 +451,7 @@ class DellaAC : public climate::Climate, public Component, public uart::UARTDevi
   bool first_publish_{true};
   uint32_t last_small_ms_{0};
   uint8_t inverter_power_{0};
+  uint8_t fan_actual_{0};   // big-frame [13]: reported live blower speed (2/4/6 = low/med/high)
 };
 
 }  // namespace della_ac

--- a/della-ac.base.yaml
+++ b/della-ac.base.yaml
@@ -196,7 +196,7 @@ remote_receiver:
           // ---------------- BIG STATUS (0x20 unsolicited / 0x21 polled) ----------------
           if (data.size() == 34 && data[2] == 0x07 && (data[9] == 0x20 || data[9] == 0x21)) {
             id(status_count) += 1;
-            id(last_status_frame).publish_state(hex);
+            if (id(verbose_logs).state) id(last_status_frame).publish_state(hex);
             id(ac_fan_code).publish_state(data[13]);
             id(indoor_temp).publish_state((float) data[15] - 0x20 + (data[31] & 0x0F) / 10.0f);
             id(coil_temp).publish_state((float) data[16] - 0x20);
@@ -204,13 +204,13 @@ remote_receiver:
             id(compressor_temp).publish_state((float) data[22] - 0x20);
             id(inverter_power).publish_state(data[24]);
             id(della_thermostat).ingest_big((float) data[15] - 0x20 + (data[31] & 0x0F) / 10.0f,
-                                            data[24]);
+                                            data[24], data[13]);
             return;
           }
 
           // ---------------- SMALL STATUS (settings; 15-byte body) ----------------
           if (data.size() == 25 && data[2] == 0x07 && data[9] == 0x11) {
-            id(last_small_frame).publish_state(hex);
+            if (id(verbose_logs).state) id(last_small_frame).publish_state(hex);
             id(della_thermostat).ingest_small(&data[8], 15);
             return;
           }
@@ -222,7 +222,7 @@ remote_receiver:
           }
 
             ESP_LOGW("aux", "UNKNOWN valid frame (%u bytes): %s", data.size(), hex.c_str());
-            id(unknown_frame).publish_state(hex);
+            if (id(verbose_logs).state) id(unknown_frame).publish_state(hex);
           };
 
           size_t pos = 0;
@@ -334,6 +334,48 @@ switch:
     turn_off_action:
       - lambda: |-
           id(della_thermostat).set_display(false);
+  - platform: template
+    name: "Health (ionizer)"
+    id: health_mode
+    icon: mdi:air-purifier
+    entity_category: config
+    lambda: |-
+      return id(della_thermostat).health_state();
+    turn_on_action:
+      - lambda: |-
+          id(della_thermostat).set_health(true);
+    turn_off_action:
+      - lambda: |-
+          id(della_thermostat).set_health(false);
+  - platform: template
+    name: "Anti-fungus"
+    id: antifungus_mode
+    icon: mdi:weather-fog
+    entity_category: config
+    # OFF-state function: the unit only honors this with the power off, so a
+    # toggle forces power off, then arms/disarms the post-shutdown dry cycle
+    # ([12].3). State reflects the unit's persistent armed flag.
+    lambda: |-
+      return id(della_thermostat).antifungus_state();
+    turn_on_action:
+      - lambda: |-
+          id(della_thermostat).set_antifungus(true);
+    turn_off_action:
+      - lambda: |-
+          id(della_thermostat).set_antifungus(false);
+  - platform: template
+    name: "Eco"
+    id: eco_mode
+    icon: mdi:leaf
+    entity_category: config
+    lambda: |-
+      return id(della_thermostat).eco_state();
+    turn_on_action:
+      - lambda: |-
+          id(della_thermostat).set_eco(true);
+    turn_off_action:
+      - lambda: |-
+          id(della_thermostat).set_eco(false);
 
 number:
   - platform: template
@@ -363,8 +405,32 @@ button:
       - script.execute: send_small_request
       - delay: 700ms
       - script.execute: send_big_request
+  - platform: template
+    name: "Self-clean"
+    id: btn_iclean
+    icon: mdi:spray-bottle
+    entity_category: config
+    # Self-clean is an OFF-state cycle (sprays/freezes/dries the evaporator).
+    # Pressing turns the unit off and starts the cycle; cancel with power.
+    on_press:
+      - lambda: 'id(della_thermostat).press_iclean();'
 
 sensor:
+  - platform: template
+    name: "Setpoint"
+    id: setpoint_temp
+    device_class: temperature
+    unit_of_measurement: °C
+    accuracy_decimals: 1
+    state_class: measurement
+    icon: mdi:thermometer-check
+    update_interval: 2s          # template polls; dedups, so it only posts on change
+    # Typed mirror of the climate target temperature — a first-class numeric
+    # entity for automations (threshold on it) and a clean "desired temp" reading.
+    lambda: |-
+      float t = id(della_thermostat).target_temperature;
+      if (std::isnan(t)) return {};
+      return t;
   - platform: template
     id: indoor_temp
     name: "Indoor temperature"
@@ -463,6 +529,26 @@ sensor:
 
 text_sensor:
   - platform: template
+    name: "Fan speed"
+    id: fan_actual_txt
+    icon: mdi:fan-chevron-up
+    update_interval: 5s
+    # Readable form of the raw "Fan speed code" diagnostic (big-frame [13]):
+    # the live blower speed the unit reports, esp. useful in Auto.
+    lambda: |-
+      return std::string(id(della_thermostat).fan_actual_str());
+  - platform: template
+    name: "Status"
+    id: ac_status
+    icon: mdi:information-outline
+    entity_category: diagnostic   # human-readable glance only; not for automations (untyped)
+    update_interval: 2s
+    # Readable one-line state summary (mode · setpoint · fan · swing · features).
+    # Updates on any change — incl. setpoint, which the HA logbook otherwise
+    # misses because it's a climate attribute, not a state change.
+    lambda: |-
+      return id(della_thermostat).status_line();
+  - platform: template
     id: last_status_frame
     name: "Last status frame"
     icon: mdi:matrix
@@ -489,3 +575,11 @@ binary_sensor:
     id: mcu_link
     name: "MCU heartbeat alive"
     device_class: connectivity
+  - platform: template
+    name: "Self-clean active"
+    id: iclean_active
+    icon: mdi:spray-bottle
+    entity_category: diagnostic
+    device_class: running
+    lambda: |-
+      return id(della_thermostat).iclean_state();

--- a/della-ac.base.yaml
+++ b/della-ac.base.yaml
@@ -385,7 +385,7 @@ number:
     min_value: 1
     max_value: 30
     step: 1
-    initial_value: 7
+    initial_value: 1   # ~2 s per frame type (small/big alternate); bus stays light
     optimistic: true
     restore_value: true
     entity_category: config

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -60,12 +60,13 @@ Packet byte index = body index + 8.
 | Byte | Field | Notes |
 |------|-------|-------|
 | 2 | v-louver (bits 0–2) \| setpoint int (bits 3–7) | louver 0 = swing, 7 = stop; temp = `8 + (v >> 3)` °C |
+| 3 | h-louver (bits 5–7) | 0 = swing, `0x20` = stop |
 | 4 | minutes-since-last-command (bits 0–5) \| half-degree flag (bit 7) | counter resets on any accepted command |
 | 5 | fan speed (bits 5–7) | `0x20` high, `0x40` med, `0x60` low, `0xA0` auto |
 | 6 | turbo (bit 6) \| mute (bit 7) | |
 | 7 | mode (bits 5–7) \| °F display (bit 1) \| sleep (bit 2) | mode `0x00` auto, `0x20` cool, `0x40` dry, `0x80` heat, `0xC0` fan |
-| 10 | power (bit 5) \| iClean (bit 2) \| health/ion (bit 1) | |
-| 12 | display (bit 4) \| mildew (bit 3) | |
+| 10 | power (bit 5) \| eco (bit 3) \| iClean (bit 2) \| health/ion (bits 0–1) | health sets both low bits (`0x03`); iClean is honoured only with power off (reports `0x04`, power bit clear) |
+| 12 | display (bit 4) \| anti-fungus (bit 3) | anti-fungus is set only with the unit off; arms a post-shutdown dry cycle |
 | 13 | inverter power limit (bit 7 enable, bits 0–6 value) | |
 | 14 | setpoint tenths | combined with byte 2 integer part |
 
@@ -75,6 +76,7 @@ Packet byte index = body index + 8.
 
 | Byte | Field | Encoding |
 |------|-------|----------|
+| 13 | reported fan speed | live blower speed: `2` low, `4` med, `6` high (in auto, reports the speed the unit picked) |
 | 15 | indoor temperature | `value − 0x20` °C, tenths in byte 31 low nibble |
 | 16–18 | evaporator coil temperature | `value − 0x20` °C |
 | 20 | outdoor temperature | `value − 0x20` °C |


### PR DESCRIPTION
Expands the Della climate integration with the swing modes, feature controls, and
sensors validated on-device. All changes live in the shared component
(`components/della_ac/della_ac.h`) and firmware body (`della-ac.base.yaml`).

## Climate
- **Horizontal and both swing** modes alongside the existing vertical (h-louver = small-frame byte[3] bits 5–7).
- Setpoint/feature writes carry the **tenths+1 compensation**, so toggling a feature no longer erodes a fractional setpoint.

## Feature controls (Home Assistant)
Each is mapped to the remote's real behaviour rather than a guessed bit:
- **Health** (ionizer, byte[10] `0x03` — both low bits), **Eco** (byte[10] bit 3), **Unit display**.
- **Self-clean** (button) and **Anti-fungus** (switch) are **off-state-only** functions on this hardware — they clear the power bit in the SET instead of acting as no-op toggles, and a powered-on command always clears a stale self-clean bit.

## Sensors
- **Setpoint** — typed temperature sensor mirroring the climate target (a clean, automation-friendly desired-temp value).
- **Fan speed** — readable live blower speed (big-frame byte[13]: `2/4/6` = low/med/high; in auto, the speed the unit picked). Raw code retained as a disabled diagnostic.
- **Status** — one-line human-readable summary (diagnostic).
- Raw frame dumps now publish **only when the Verbose toggle is on**, keeping the HA recorder quiet; feature entities are filed under Configuration/Diagnostic.

## Docs
README feature list and `docs/PROTOCOL.md` field maps updated to match (byte 3 h-louver, byte 10 health/eco/iClean, byte 12 anti-fungus, big-frame byte 13 fan speed).

## Known limitation
After an ESPHome SET, the IR remote is briefly locked out until the remote's power button is pressed (tracked in #12).

🤖 Generated with [Claude Code](https://claude.com/claude-code)