### PR TITLE
Bump release image to 1.1.0

### DIFF
--- a/della-ac.factory.yaml
+++ b/della-ac.factory.yaml
@@ -19,7 +19,7 @@ esphome:
   min_version: 2026.5.3
   project:
     name: adamgranted.della-ac
-    version: "1.0.0"
+    version: "1.1.0"
 
 packages:
   base: !include della-ac.base.yaml


### PR DESCRIPTION
Version bump for the v1.1.0 release (swing, feature controls, status/setpoint/fan-speed sensors, 1s default polling).