### PR TITLE
Add Della Motto JA 12K support (2nd model): accept 35-byte + 0x2C status frames

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
   </a>
   <h2>esphome-della-ac</h2>
   <p align="center">
-      <p><b>Local Home Assistant control for the Della 048-MS mini split</b></p>
+      <p><b>Local Home Assistant control for AUX-OEM Della mini splits</b></p>
   </p>
 
   <p align="center">
@@ -23,16 +23,32 @@
 
 <br>
 
-ESPHome firmware that exposes a **Della 048-MS** mini split as a full Home Assistant
+ESPHome firmware that exposes an **AUX-OEM Della** mini split as a full Home Assistant
 thermostat — no cloud, no Tuya account. It replaces the stock Wi-Fi dongle with an
 [SMLIGHT SLWF-01](https://smlight.tech/) running this firmware, plug-and-play with the
-Della's USB-A service port.
+Della's USB-A service port. Developed on a **Della 048-MS**; see
+[Supported units](#supported-units) for the model list.
 
-The Della 048-MS does **not** speak the TCL protocol its USB port suggests — it is an
-**AUX OEM** unit speaking the AUX HVAC serial protocol at **4800 baud, 8E1**, on an
+These units do **not** speak the TCL protocol their USB port suggests — they are
+**AUX OEM** hardware speaking the AUX HVAC serial protocol at **4800 baud, 8E1**, on an
 open-drain line. (Sampling that line at the obvious 9600 baud yields a convincing but
 bogus byte stream; that aliasing trap is why earlier attempts never worked.) The full
 story and byte-level map are in [`docs/PROTOCOL.md`](docs/PROTOCOL.md).
+
+
+## Supported units
+
+One firmware serves every model — it auto-detects the AC's status-frame variant at
+runtime, so there is **a single build to flash regardless of model** (no per-model
+images to choose between).
+
+| Model | Control | Telemetry | Notes |
+|-------|:------:|:--------:|-------|
+| **Della 048-MS** | ✅ | ✅ | Reference unit — fully verified |
+| **Della Motto JA 12K** (`12K1VRH-20S-JA`) | ✅ | 🧪 beta | Same protocol; setpoint / mode / fan / power confirmed. Telemetry decoded from an idle capture — pending one active-cooling log to confirm the compressor/inverter fields ([#11](https://github.com/adamgranted/esphome-della-ac/issues/11)) |
+
+Other AUX-built Della / AUX-OEM units very likely work. If yours isn't listed, open an
+issue with a `verbose`-on log capture and it can usually be added in a line or two.
 
 
 ## Features
@@ -57,8 +73,8 @@ story and byte-level map are in [`docs/PROTOCOL.md`](docs/PROTOCOL.md).
 
 ## Hardware
 
-- A **Della 048-MS** mini split (other AUX-built Della / AUX-OEM units likely work — see
-  [`docs/PROTOCOL.md`](docs/PROTOCOL.md)).
+- An **AUX-OEM Della** mini split — see [Supported units](#supported-units) for confirmed
+  models (other AUX-built Della units very likely work).
 - A **SMLIGHT SLWF-01** (ESP-12F). It drops straight into the indoor unit's USB-A service
   port and already carries everything the link needs — the USB-A header, 5 V regulation,
   and the level shifting between the ESP8266's 3.3 V logic and the AC's 5 V TTL UART

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ images to choose between).
 | Model | Control | Telemetry | Notes |
 |-------|:------:|:--------:|-------|
 | **Della 048-MS** | ✅ | ✅ | Reference unit — fully verified |
-| **Della Motto JA 12K** (`12K1VRH-20S-JA`) | ✅ | 🧪 beta | Same protocol; setpoint / mode / fan / power confirmed. Telemetry decoded from an idle capture — pending one active-cooling log to confirm the compressor/inverter fields ([#11](https://github.com/adamgranted/esphome-della-ac/issues/11)) |
+| **Della Motto JA 12K** (`12K1VRH-20S-JA`) | ✅ | ✅ | Same AUX protocol as the 048-MS (35-byte status frame). Confirmed on idle + active-cooling captures ([#11](https://github.com/adamgranted/esphome-della-ac/issues/11)) |
 
 Other AUX-built Della / AUX-OEM units very likely work. If yours isn't listed, open an
 issue with a `verbose`-on log capture and it can usually be added in a line or two.

--- a/della-ac.base.yaml
+++ b/della-ac.base.yaml
@@ -193,11 +193,13 @@ remote_receiver:
             return;
           }
 
-          // ---------------- BIG STATUS (0x20 unsolicited / 0x21 polled) ----------------
+          // ------------- BIG STATUS (0x20 unsolicited / 0x21 polled / 0x2C alt) -------------
           // Length self-describes via the body byte: 34B (Della 048-MS) and 35B (Della
           // Motto JA 12K, one extra trailing pad before the CRC) share this exact layout
-          // and field offsets, so one decode path serves both.
-          if ((data.size() == 34 || data.size() == 35) && data[2] == 0x07 && (data[9] == 0x20 || data[9] == 0x21)) {
+          // and field offsets, so one decode path serves both. 0x2C is an alternate status
+          // frame (same layout) the AC interleaves with the polled 0x21.
+          if ((data.size() == 34 || data.size() == 35) && data[2] == 0x07 &&
+              (data[9] == 0x20 || data[9] == 0x21 || data[9] == 0x2C)) {
             id(status_count) += 1;
             if (id(verbose_logs).state) id(last_status_frame).publish_state(hex);
             id(ac_fan_code).publish_state(data[13]);

--- a/della-ac.base.yaml
+++ b/della-ac.base.yaml
@@ -141,7 +141,7 @@ remote_receiver:
           id(last_rx_ms) = now;
 
           // pulses -> bits (4800 baud, bit = 206us; highs recentred +77us
-          // for the MCU's 0..155us release lag). 34-byte frame ~ 389 bits.
+          // for the MCU's 0..155us release lag). 34/35-byte status frame ~ 389-400 bits.
           std::vector<bool> bits;
           bits.reserve(520);
           for (auto v : x) {
@@ -194,7 +194,10 @@ remote_receiver:
           }
 
           // ---------------- BIG STATUS (0x20 unsolicited / 0x21 polled) ----------------
-          if (data.size() == 34 && data[2] == 0x07 && (data[9] == 0x20 || data[9] == 0x21)) {
+          // Length self-describes via the body byte: 34B (Della 048-MS) and 35B (Della
+          // Motto JA 12K, one extra trailing pad before the CRC) share this exact layout
+          // and field offsets, so one decode path serves both.
+          if ((data.size() == 34 || data.size() == 35) && data[2] == 0x07 && (data[9] == 0x20 || data[9] == 0x21)) {
             id(status_count) += 1;
             if (id(verbose_logs).state) id(last_status_frame).publish_state(hex);
             id(ac_fan_code).publish_state(data[13]);

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -23,20 +23,30 @@ FRAMES = {
     # layout, but 35 bytes: one extra trailing pad byte before the 2-byte CRC.
     "big_status_motto": "BB 00 07 00 00 00 19 00 01 21 E0 20 00 00 00 36 37 37 37 "
                         "64 38 39 38 39 00 00 51 2D 00 00 00 03 00 13 49",
+    # Motto JA, captured while actively cooling (setpoint 18C): inverter power and
+    # fan now non-zero, confirming those fields decode under the shared map.
+    "big_status_motto_active": "BB 00 07 00 00 00 19 00 01 21 E0 21 00 06 6C 36 32 32 32 "
+                               "64 35 39 38 39 33 0F 81 4D 0E 00 00 00 00 43 1A",
+    # Motto JA alternate status frame (type 0x2C): same layout/offsets as 0x21,
+    # interleaved with the polled frame. The firmware accepts it alongside 0x20/0x21.
+    "big_status_motto_alt2c":  "BB 00 07 00 00 00 19 00 01 2C E0 21 00 06 6B 36 33 33 33 "
+                               "64 35 39 38 39 33 0F 81 4D 0E 00 00 00 00 42 0E",
 }
 
 # Big-status field map (mirrors the YAML lambda). Both the 34-byte 048-MS frame
 # and the 35-byte Motto frame use these exact offsets — that equivalence is the
 # whole reason a single firmware serves both. Keyed by FRAMES name.
 BIG_STATUS_EXPECTED = {
-    "big_status":       dict(indoor=21.3, coil=14, outdoor=26, compressor=32, inverter=20, fan=2),
-    "big_status_motto": dict(indoor=22.3, coil=23, outdoor=24, compressor=24, inverter=0, fan=0),
+    "big_status":              dict(indoor=21.3, coil=14, outdoor=26, compressor=32, inverter=20, fan=2),
+    "big_status_motto":        dict(indoor=22.3, coil=23, outdoor=24, compressor=24, inverter=0,  fan=0),
+    "big_status_motto_active": dict(indoor=22.0, coil=18, outdoor=21, compressor=24, inverter=51, fan=6),
+    "big_status_motto_alt2c":  dict(indoor=22.0, coil=19, outdoor=21, compressor=24, inverter=51, fan=6),
 }
 
 
 def decode_big_status(data: bytes) -> dict:
     """Decode an AUX big-status frame exactly as della-ac.base.yaml does."""
-    assert data[2] == 0x07 and data[9] in (0x20, 0x21), "not a big-status frame"
+    assert data[2] == 0x07 and data[9] in (0x20, 0x21, 0x2C), "not a big-status frame"
     assert data[19] == 0x64 and data[23] == 0x39, "internal markers misaligned"
     return dict(
         indoor=round(data[15] - 0x20 + (data[31] & 0x0F) / 10.0, 1),

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -19,7 +19,33 @@ FRAMES = {
     "ping_answer":   "BB 00 01 80 01 00 08 00 1C 27 00 00 00 00 00 00 1E 58",
     "big_status":    "BB 00 07 00 00 00 18 00 01 20 E4 21 00 02 55 35 2E 2E 2E "
                      "64 3A 3D 40 39 14 06 A4 2C 08 00 00 03 54 47",
+    # Della Motto JA 12K (model 12K1VRH-20S-JA, issue #11). Same AUX big-status
+    # layout, but 35 bytes: one extra trailing pad byte before the 2-byte CRC.
+    "big_status_motto": "BB 00 07 00 00 00 19 00 01 21 E0 20 00 00 00 36 37 37 37 "
+                        "64 38 39 38 39 00 00 51 2D 00 00 00 03 00 13 49",
 }
+
+# Big-status field map (mirrors the YAML lambda). Both the 34-byte 048-MS frame
+# and the 35-byte Motto frame use these exact offsets — that equivalence is the
+# whole reason a single firmware serves both. Keyed by FRAMES name.
+BIG_STATUS_EXPECTED = {
+    "big_status":       dict(indoor=21.3, coil=14, outdoor=26, compressor=32, inverter=20, fan=2),
+    "big_status_motto": dict(indoor=22.3, coil=23, outdoor=24, compressor=24, inverter=0, fan=0),
+}
+
+
+def decode_big_status(data: bytes) -> dict:
+    """Decode an AUX big-status frame exactly as della-ac.base.yaml does."""
+    assert data[2] == 0x07 and data[9] in (0x20, 0x21), "not a big-status frame"
+    assert data[19] == 0x64 and data[23] == 0x39, "internal markers misaligned"
+    return dict(
+        indoor=round(data[15] - 0x20 + (data[31] & 0x0F) / 10.0, 1),
+        coil=data[16] - 0x20,
+        outdoor=data[20] - 0x20,
+        compressor=data[22] - 0x20,
+        inverter=data[24],
+        fan=data[13],
+    )
 
 # A real captured heartbeat burst (ESPHome remote.raw timings, microseconds).
 # Decodes to the ping frame above.
@@ -35,6 +61,16 @@ def test_crc_matches_frame(name, hexstr):
     data = bytes.fromhex(hexstr.replace(" ", ""))
     body, expected = data[:-2], (data[-2] << 8) | data[-1]
     assert crc16_rfc1071(body) == expected, f"{name} CRC mismatch"
+
+
+@pytest.mark.parametrize("name", BIG_STATUS_EXPECTED)
+def test_big_status_decodes_for_both_models(name):
+    # The 34-byte (048-MS) and 35-byte (Motto JA) frames decode to sensible,
+    # self-consistent values under one shared field map. The firmware gate must
+    # therefore accept both lengths; this guards against it regressing to 34-only.
+    data = bytes.fromhex(FRAMES[name].replace(" ", ""))
+    assert len(data) in (34, 35)
+    assert decode_big_status(data) == BIG_STATUS_EXPECTED[name]
 
 
 def test_heartbeat_decodes_to_ping():


### PR DESCRIPTION
## Summary

Adds the **Della Motto JA 12K** (`12K1VRH-20S-JA`) as a second supported unit and rebrands the project from "Della 048-MS only" to the **AUX-OEM Della family**. It's the same AUX protocol — one firmware auto-detects the variant at runtime, so there is still a single build to flash (no per-model images).

## What was wrong

The Motto's control frame is byte-identical to the 048-MS (so setpoint / mode / fan / power already worked), but its **big/telemetry frame is 35 bytes vs the 048's 34** — one extra trailing pad before the 2-byte CRC, otherwise identical header, type byte, field offsets and internal markers. The decode gate hard-coded `size == 34`, so the Motto's status frame was dropped as `UNKNOWN` and every telemetry sensor read blank. The CRC verifies on both, so it was purely a decode gap.

## Changes

- **`della-ac.base.yaml`** — the big-status gate now accepts **34- or 35-byte** frames and types **`0x20` / `0x21` / `0x2C`** (the `0x2C` alternate status frame both units interleave with the polled `0x21`). Field offsets and the RFC1071 CRC are unchanged; the 048-MS decodes byte-for-byte identically.
- **`tests/test_protocol.py`** — guards the new frames' CRCs and asserts the 34- and 35-byte frames decode to expected values under one shared field map (idle, active-cooling, and `0x2C`).
- **`README.md`** — rebranded to the AUX-OEM Della family with a support matrix.

## Validation

Field-tested by a Motto JA 12K owner (#11) on the `v1.2.0-beta.1` pre-release:
- All telemetry populated correctly.
- The active-cooling capture confirms the field map — inverter power `0 → 51` and fan `0 → 6` with the compressor running, coil tracking down `23 → 18 °C`.
- `16/16` protocol tests pass.

Refs #11.