### PR TITLE
Bump release image to 1.2.0

### DIFF
--- a/della-ac.factory.yaml
+++ b/della-ac.factory.yaml
@@ -19,7 +19,7 @@ esphome:
   min_version: 2026.5.3
   project:
     name: adamgranted.della-ac
-    version: "1.1.0"
+    version: "1.2.0"
 
 packages:
   base: !include della-ac.base.yaml


### PR DESCRIPTION
## Summary

Bumps the factory release image to **1.2.0** so the flashed device self-reports the new version, ahead of cutting the **v1.2.0** stable release.

v1.2.0 ships **Della Motto JA 12K** support (35-byte + `0x2C` status frames, #15) on top of v1.1.0 — field-validated by a Motto owner (#11).

Merge this, then the v1.2.0 release gets tagged off `master` (which rebuilds the one-click web flasher to 1.2.0).