### PR TITLE
Fix setpoint corruption above ~78 °F (uint8_t tenths overflow)

### DIFF
--- a/components/della_ac/della_ac.h
+++ b/components/della_ac/della_ac.h
@@ -262,7 +262,10 @@ class DellaAC : public climate::Climate, public Component, public uart::UARTDevi
     b[4] &= 0x80;
     float t = 8.0f + ((b[2] >> 3) & 0x1F) + b[14] / 10.0f;
     uint8_t send_int = (uint8_t) t;
-    uint8_t send_tenths = ((uint8_t) lroundf(t * 10.0f)) % 10;
+    // Keep lroundf as a long for the % 10. Casting to uint8_t first wraps at
+    // 256 — and t*10 >= 256 for t >= 25.6 C (~78 F) — which corrupted the
+    // tenths digit and mis-set every setpoint above ~78 F.
+    uint8_t send_tenths = lroundf(t * 10.0f) % 10;
     if (send_tenths != 0 && send_tenths != 5) {
       send_tenths += 1;
       if (send_tenths == 10) { send_tenths = 0; send_int += 1; }
@@ -352,7 +355,9 @@ class DellaAC : public climate::Climate, public Component, public uart::UARTDevi
         t = 8.0f + ((b[2] >> 3) & 0x1F) + b[14] / 10.0f;  // preserve stored
       }
       uint8_t send_int = (uint8_t) t;
-      uint8_t send_tenths = ((uint8_t) lroundf(t * 10.0f)) % 10;
+      // long % 10, not (uint8_t) first: t*10 >= 256 for t >= 25.6 C (~78 F)
+      // wrapped the cast and corrupted the tenths — see prepare_set_().
+      uint8_t send_tenths = lroundf(t * 10.0f) % 10;
       if (send_tenths != 0 && send_tenths != 5) {
         send_tenths += 1;                  // unit will store tenths-1 = intended
         if (send_tenths == 10) { send_tenths = 0; send_int += 1; }

--- a/della-ac.factory.yaml
+++ b/della-ac.factory.yaml
@@ -19,7 +19,7 @@ esphome:
   min_version: 2026.5.3
   project:
     name: adamgranted.della-ac
-    version: "1.2.0"
+    version: "1.2.1"
 
 packages:
   base: !include della-ac.base.yaml

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -114,3 +114,53 @@ def test_parse_merges_chunked_burst(tmp_path):
     bursts = parse(str(log))
     assert len(bursts) == 1
     assert len(bursts[0][1]) == 8
+
+
+# ---------------------------------------------------------------------------
+# Setpoint encoder — mirrors della_ac.h control() / prepare_set_().
+#
+# Regression guard for issue #18. The tenths digit was computed as
+#     uint8_t send_tenths = ((uint8_t) lroundf(t * 10.0f)) % 10;
+# and t*10 >= 256 for t >= 25.6 C (~78 F), so the uint8_t cast wrapped (256 -> 0)
+# and corrupted every setpoint above ~78 F (setting 78 F stored 77 F, etc.). The
+# fix keeps lroundf a long for the % 10. `truncate_u8=True` reproduces the old
+# arithmetic so the guard provably bites.
+# ---------------------------------------------------------------------------
+
+SETPOINT_MIN_C, SETPOINT_MAX_C = 16.0, 32.0
+
+
+def _encode_tenths(t, truncate_u8=False):
+    send_int = int(t)                                  # (uint8_t) t, in range 16..32
+    raw = round(t * 10.0)                              # lroundf(t * 10.0f)
+    send_tenths = (raw & 0xFF if truncate_u8 else raw) % 10
+    if send_tenths not in (0, 5):
+        send_tenths += 1                               # unit erodes .x -> .x-1
+        if send_tenths == 10:
+            send_tenths = 0
+            send_int += 1
+    return send_int, send_tenths
+
+
+def _unit_stores_f(send_int, send_tenths):
+    erosion = 0.1 if send_tenths not in (0, 5) else 0.0   # MCU erodes non-.0/.5 by 0.1
+    stored_c = round(send_int + send_tenths / 10.0 - erosion, 1)
+    return stored_c * 9 / 5 + 32
+
+
+def _set_read_f(fahrenheit, truncate_u8=False):
+    t = round((fahrenheit - 32) * 5 / 9 * 10) / 10       # HA converts F -> C at 0.1
+    t = min(max(t, SETPOINT_MIN_C), SETPOINT_MAX_C)
+    return _unit_stores_f(*_encode_tenths(t, truncate_u8))
+
+
+@pytest.mark.parametrize("fahrenheit", list(range(61, 90)))  # 16.1..31.7 C, in-range
+def test_setpoint_holds_across_full_range(fahrenheit):
+    shown = _set_read_f(fahrenheit)
+    assert abs(shown - fahrenheit) <= 0.25, f"{fahrenheit}F stored as {shown:.1f}F"
+
+
+def test_setpoint_overflow_regression():
+    # 78 F = 25.6 C is the exact case from issue #18.
+    assert abs(_set_read_f(78) - 78) <= 0.25            # fixed encoder holds it
+    assert abs(_set_read_f(78, truncate_u8=True) - 78) > 0.5   # old encoder broke it


### PR DESCRIPTION
## Summary

A user on a Della Motto 9k (#18) reported the setpoint "jumping around" and refusing to hold a temperature — e.g. setting **78 °F beeped and landed on 77 °F**, and higher values bounced erratically ("goes back to 84/85"). Their own logs pinned it down: firmware logged `Target: 25.6 -> 25.0 C` and the SET carried tenths = 0.

**Root cause:** in both `control()` and `prepare_set_()` the setpoint tenths were computed as

```cpp
uint8_t send_tenths = ((uint8_t) lroundf(t * 10.0f)) % 10;
```

For `t >= 25.6 °C` (~78 °F), `t * 10 >= 256` **overflows the `uint8_t` cast** (wraps mod 256) before the `% 10`, so the tenths digit is garbage above ~78 °F. Below that it's correct — which is why it went unnoticed (the reference 048-MS is normally kept around 68 °F).

It was never model-specific: the control frame is byte-identical across the 048-MS / Motto 12K / 9k, and the encoder runs the same on all of them. Any unit corrupts its setpoint above ~78 °F.

### Reproduced across the range (buggy encoder)

| set °F | intended °C | stored | shows |
|---:|---:|---:|:--|
| ≤ 77 | ≤ 25.5 | correct | ✅ |
| 78 | 25.6 | 25.0 | 77 °F ❌ |
| 79 | 26.1 | 26.5 | 79.7 °F ❌ |
| 84 | 28.9 | 28.3 | 82.9 °F ❌ |

## Fix

Keep `lroundf` as a `long` for the `% 10` (drop the `(uint8_t)` cast). One line in each of the two call sites; behaviour below ~78 °F is unchanged.

## Test

Adds a setpoint-encoder mirror to `tests/test_protocol.py` that encodes the full **61–89 °F** in-range span and asserts each value holds within the °C storage grid, plus an explicit **78 °F** guard that reproduces the old truncating arithmetic to prove the guard bites. `46 passed`.

## Release

Bumps the release image to **1.2.1** so the published firmware + web flasher pick up the fix.

Refs #18