### PR TITLE
Document Della Serena 18K support

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ images to choose between).
 |-------|:------:|:--------:|-------|
 | **Della 048-MS** | ✅ | ✅ | Reference unit — fully verified |
 | **Della Motto JA 12K** (`12K1VRH-20S-JA`) | ✅ | ✅ | Same AUX protocol as the 048-MS (35-byte status frame). Confirmed on idle + active-cooling captures ([#11](https://github.com/adamgranted/esphome-della-ac/issues/11)) |
+| **Della Serena Series 18K** (`18K2VR-22S-M-I+O`) | ✅ | ✅ | Confirmed working by a community user ([Home Assistant report](https://community.home-assistant.io/t/della-ac-integration/756819/16)) |
 
 Other AUX-built Della / AUX-OEM units very likely work. If yours isn't listed, open an
 issue with a `verbose`-on log capture and it can usually be added in a line or two.


### PR DESCRIPTION
## Summary

- add the Della Serena Series 18K to the supported-units matrix
- retain the exact `18K2VR-22S-M-I+O` system SKU
- link the Home Assistant community confirmation that the integration works

## Model naming

Della markets the unit as the **Serena Series 18000 BTU** model and uses `18K2VR-22S-M-I+O` as the complete system SKU in its product catalog and support documentation. The README therefore uses the shorter **Della Serena Series 18K** display name while preserving the exact SKU alongside it.

## Impact

Owners of this Serena model can now see that control and telemetry have been confirmed working with the existing universal firmware.

## Validation

- verified the linked Home Assistant community report
- checked the model name and SKU against Della's product and support pages
- `git diff --check`
